### PR TITLE
Remove entries without a top-level domain

### DIFF
--- a/HOSTS.txt
+++ b/HOSTS.txt
@@ -5543,7 +5543,7 @@
 0.0.0.0    eroticneko.tumblr.com
 0.0.0.0    eroticnetwork.net
 0.0.0.0    eroticpics.com
-0.0.0.0    eroticpics.com	
+0.0.0.0    eroticpics.com
 0.0.0.0    eroticproviderguide.com
 0.0.0.0    eroticrelease.com
 0.0.0.0    erotictonaughty.com
@@ -16782,7 +16782,7 @@
 0.0.0.0    sexypornstargifs.tumblr.com
 0.0.0.0    sexypp.com
 0.0.0.0    sexystream.cz
-0.0.0.0    sexystream.cz	
+0.0.0.0    sexystream.cz
 0.0.0.0    sexytoonporn.com
 0.0.0.0    sexytout.com
 0.0.0.0    sexytube.com
@@ -25721,7 +25721,7 @@
 0.0.0.0    www.eroticneko.tumblr.com
 0.0.0.0    www.eroticnetwork.net
 0.0.0.0    www.eroticpics.com
-0.0.0.0    www.eroticpics.com	
+0.0.0.0    www.eroticpics.com
 0.0.0.0    www.eroticproviderguide.com
 0.0.0.0    www.eroticrelease.com
 0.0.0.0    www.erotictonaughty.com
@@ -36447,7 +36447,7 @@
 0.0.0.0    www.sexypornstargifs.tumblr.com
 0.0.0.0    www.sexypornvideo.org
 0.0.0.0    www.sexystream.cz
-0.0.0.0    www.sexystream.cz	
+0.0.0.0    www.sexystream.cz
 0.0.0.0    www.sexytoonporn.com
 0.0.0.0    www.sexytout.com
 0.0.0.0    www.sexytube.com

--- a/HOSTS.txt
+++ b/HOSTS.txt
@@ -2096,7 +2096,6 @@
 0.0.0.0    bdsmvideos.net
 0.0.0.0    bdsmxxxmovies.com
 0.0.0.0    bdv.bidvertiser.com
-0.0.0.0    be
 0.0.0.0    be-onlinemarketing.com
 0.0.0.0    be-wild.pl
 0.0.0.0    be.pornosearch.guru
@@ -41393,7 +41392,6 @@
 0.0.0.0    xxxtube.com
 0.0.0.0    xxxtube2022.com
 0.0.0.0    xxxtube69.com
-0.0.0.0    xxxtubeasian
 0.0.0.0    xxxtubebest.com
 0.0.0.0    xxxtubezoo.com
 0.0.0.0    xxxvideo4.com


### PR DESCRIPTION
These entries cause problems when this list is used in blocker extensions like uBlock Origin (ex. the "be" entry causes every site with a .be domain to be blocked)