### PR TITLE
Entries in the blocklist that are not domains

### DIFF
--- a/HOSTS.txt
+++ b/HOSTS.txt
@@ -76986,7 +76986,6 @@
 0.0.0.0    www.sexcounter.com
 0.0.0.0    www.sexcrown.com
 0.0.0.0    www.sexdam.pro
-0.0.0.0    www.sexdating
 0.0.0.0    www.sexdating.com
 0.0.0.0    www.sexdep.pro
 0.0.0.0    www.sexdesire.asiabusty.com

--- a/HOSTS.txt
+++ b/HOSTS.txt
@@ -41531,7 +41531,6 @@
 0.0.0.0    sexdam69.net
 0.0.0.0    sexdamvl.com
 0.0.0.0    sexdate.nl
-0.0.0.0    sexdating
 0.0.0.0    sexdating.com
 0.0.0.0    sexdcm.com
 0.0.0.0    sexdem.cc


### PR DESCRIPTION
Hi! In this pull request, I removed 2 entries that were not domains.

```
  [✓] Parsed 87069 exact domains and 0 ABP-style domains (blocking, ignored 1 non-domain entries)
      Sample of non-domain entries:
        - sexdating
```